### PR TITLE
Simple Scheduling for Upgrades (Maintenance Window)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ docker run --rm stffabi/watchtower --help
 
 * `--host, -h` Docker daemon socket to connect to. Defaults to "unix:///var/run/docker.sock" but can be pointed at a remote Docker host by specifying a TCP endpoint as "tcp://hostname:port". The host value can also be provided by setting the `DOCKER_HOST` environment variable.
 * `--interval, -i` Poll interval (in seconds). This value controls how frequently watchtower will poll for new images. Defaults to 300 seconds (5 minutes).
+* `--schedule, -s` [Cron expression](https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format) which defines when and how often to check for new images. Either `--interval` or the schedule expression could be defined, but not both.
 * `--no-pull` Do not pull new images. When this flag is specified, watchtower will not attempt to pull new images from the registry. Instead it will only monitor the local image cache for changes. Use this option if you are building new images directly on the Docker host without pushing them to a registry.
 * `--cleanup` Remove old images after updating. When this flag is specified, watchtower will remove the old image after restarting a container with a new image. Use this option to prevent the accumulation of orphaned images on your system as containers are updated.
 * `--tlsverify` Use TLS when connecting to the Docker socket and verify the server's certificate.

--- a/main.go
+++ b/main.go
@@ -4,20 +4,21 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 	"time"
 
+	"strconv"
+
 	log "github.com/Sirupsen/logrus"
+	"github.com/robfig/cron"
 	"github.com/stffabi/watchtower/actions"
 	"github.com/stffabi/watchtower/container"
 	"github.com/urfave/cli"
 )
 
 var (
-	wg           sync.WaitGroup
 	client       container.Client
-	pollInterval time.Duration
+	scheduleSpec string
 	cleanup      bool
 	noRestart    bool
 )
@@ -44,6 +45,11 @@ func main() {
 			Usage:  "poll interval (in seconds)",
 			Value:  300,
 			EnvVar: "WATCHTOWER_POLL_INTERVAL",
+		},
+		cli.StringFlag{
+			Name:   "schedule, s",
+			Usage:  "the cron expression which defines when to update",
+			EnvVar: "WATCHTOWER_SCHEDULE",
 		},
 		cli.BoolFlag{
 			Name:   "no-pull",
@@ -86,7 +92,17 @@ func before(c *cli.Context) error {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	pollInterval = time.Duration(c.Int("interval")) * time.Second
+	pollingSet := c.IsSet("interval")
+	cronSet := c.IsSet("schedule")
+
+	if pollingSet && cronSet {
+		log.Fatal("Only schedule or interval can be defined, not both.")
+	} else if cronSet {
+		scheduleSpec = c.String("schedule")
+	} else {
+		scheduleSpec = "@every " + strconv.Itoa(c.Int("interval")) + "s"
+	}
+
 	cleanup = c.GlobalBool("cleanup")
 	noRestart = c.GlobalBool("no-restart")
 
@@ -97,40 +113,57 @@ func before(c *cli.Context) error {
 	}
 
 	client = container.NewClient(!c.GlobalBool("no-pull"))
-
-	handleSignals()
 	return nil
 }
 
-func start(c *cli.Context) {
+func start(c *cli.Context) error {
 	names := c.Args()
 
 	if err := actions.CheckPrereqs(client, cleanup); err != nil {
 		log.Fatal(err)
 	}
 
-	for {
-		wg.Add(1)
-		if err := actions.Update(client, names, cleanup, noRestart); err != nil {
-			fmt.Println(err)
-		}
-		wg.Done()
+	tryLockSem := make(chan bool, 1)
+	tryLockSem <- true
 
-		time.Sleep(pollInterval)
+	cron := cron.New()
+	err := cron.AddFunc(
+		scheduleSpec,
+		func() {
+			select {
+			case v := <-tryLockSem:
+				defer func() { tryLockSem <- v }()
+				if err := actions.Update(client, names, cleanup, noRestart); err != nil {
+					fmt.Println(err)
+				}
+			default:
+				log.Debug("Skipped another update already running.")
+			}
+
+			nextRuns := cron.Entries()
+			if len(nextRuns) > 0 {
+				log.Debug("Scheduled next run: " + nextRuns[0].Next.String())
+			}
+		})
+
+	if err != nil {
+		return err
 	}
-}
 
-func handleSignals() {
+	log.Info("First run: " + cron.Entries()[0].Schedule.Next(time.Now()).String())
+	cron.Start()
+
 	// Graceful shut-down on SIGINT/SIGTERM
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	signal.Notify(c, syscall.SIGTERM)
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+	signal.Notify(interrupt, syscall.SIGTERM)
 
-	go func() {
-		<-c
-		wg.Wait()
-		os.Exit(1)
-	}()
+	<-interrupt
+	cron.Stop()
+	log.Info("Waiting for running update to be finished...")
+	<-tryLockSem
+	os.Exit(1)
+	return nil
 }
 
 func setEnvOptStr(env string, opt string) error {


### PR DESCRIPTION
Possibility to define a cron expression which specifies when to check for updated images. This allows to have a schedule in which updates should be made and therefore one could define a maintenance window.

Schedules can be defined as [Cron expression](https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format).

Build for this feature can be found on docker hub `stffabi/watchtower:feature_cron`.

Fix for CenturyLinkLabs/watchtower#12.
